### PR TITLE
Add rlang to package section

### DIFF
--- a/content/packages.md
+++ b/content/packages.md
@@ -105,6 +105,8 @@ As well as [tidyr](http://tidyr.tidyverse.org), and [dplyr](http://dplyr.tidyver
 
 As well as [purrr](http://purrr.tidyverse.org) which faciliates functional programming, there are two tidyverse packages that help with general programming challenges:
 
+* [rlang](http://rlang.tidyverse.org) provides tools to work with core language features of R and the tidyverse
+
 * [magrittr](http://magrittr.tidyverse.org) provides the pipe, `%>%` used 
   throughout the tidyverse. It also provide a number of more specialised
   piping operators (like `%$%` and `%<>%`) that can be useful in other places.


### PR DESCRIPTION
Shouldn't rlang also be included. On [rlang](http://rlang.tidyverse.org) it says that it is part of tidyverse.