### PR TITLE
Use the actual year this was written

### DIFF
--- a/content/articles/2017-08-08-contributing.md
+++ b/content/articles/2017-08-08-contributing.md
@@ -2,7 +2,7 @@
 title: Contributing code to the tidyverse
 author: Jim Hester
 slug: contributing
-date: 2018-08-14
+date: 2017-08-14
 photo:
   url: https://unsplash.com/photos/qFxS5FkUSAQ
   author: Yuriy Rzhemovskiy


### PR DESCRIPTION
I was apparently being optimistic when I wrote the date.

I guess this might break links to the article, not sure there is much we can do about it...