### PR TITLE
Correct link for Solutions and notes for R4DS

### DIFF
--- a/content/learn.md
+++ b/content/learn.md
@@ -20,6 +20,9 @@ We highly recommend pairing R4DS with the [RStudio cheatsheets](https://www.rstu
 * [ggplot2: elegant graphics for data science](http://amzn.to/2tYdTqd) by 
   Hadley Wickham. Goes into greater depth into the ggplot2 visualisation 
   system.
+  
+* [Solutions and notes for R4DS](https://jrnold.github.io/r4ds-exercise-solutions/) 
+  by Jeffrey B. Arnold. Work in progress.
 
 ## Online courses
 


### PR DESCRIPTION
Corrects the link and re-adds the resource removed in 0fc924fb032a98d95d9e9049afc67e34851fee9a .