### PR TITLE
Fix link to rlang package page.

### DIFF
--- a/content/packages.md
+++ b/content/packages.md
@@ -120,8 +120,6 @@ In addition to [tidyr](http://tidyr.tidyverse.org), and [dplyr](http://dplyr.tid
 
 In addition to [purrr](http://purrr.tidyverse.org), which provides very consistent and natural methods for iterating on R objects, there are three tidyverse packages that help with general programming challenges:
 
-* [rlang](http://rlang.r-lib.org/) provides tools to work with core language features of R and the tidyverse
-
 * [magrittr](http://magrittr.tidyverse.org) provides the pipe, `%>%` used
   throughout the tidyverse. It also provide a number of more specialised
   piping operators (like `%$%` and `%<>%`) that can be useful in other places.

--- a/content/packages.md
+++ b/content/packages.md
@@ -120,7 +120,7 @@ In addition to [tidyr](http://tidyr.tidyverse.org), and [dplyr](http://dplyr.tid
 
 In addition to [purrr](http://purrr.tidyverse.org), which provides very consistent and natural methods for iterating on R objects, there are three tidyverse packages that help with general programming challenges:
 
-* [rlang](http://rlang.tidyverse.org) provides tools to work with core language features of R and the tidyverse
+* [rlang](http://rlang.r-lib.org/) provides tools to work with core language features of R and the tidyverse
 
 * [magrittr](http://magrittr.tidyverse.org) provides the pipe, `%>%` used
   throughout the tidyverse. It also provide a number of more specialised


### PR DESCRIPTION
* Fixes #145.
* _n.b._ Since rlang is now part of r-lib, should we remove it from the tidyverse package index entirely?