### PR TITLE
Remove past event

### DIFF
--- a/data/events.yaml
+++ b/data/events.yaml
@@ -7,16 +7,6 @@ events:
   what: |
     If you see this event, something has gone wrong
 
-- url: https://www.rstudio.com/workshops/applied-machine-learning/
-  title: Machine Learning Workshop with Max Kuhn
-  where: Washington, DC
-  when:  Aug 23-24
-  iso8601: 2018-08-24
-  what: |
-    This two-day course will provide an overview of using R for supervised learning.
-    The session will step through the process of building, visualizing, testing, and
-    comparing models that are focused on prediction.
-
 - url: https://www.rstudio.com/workshops/what-they-forgot-to-teach-you-about-r/
   title: What they forgot to teach you about R with Jenny Bryan and Jim Hester
   where: Seattle, WA


### PR DESCRIPTION
* Remove Max's workshop (already occurred), should make rstudio::conf show up again.