### PR TITLE
Source the user rprofile after the project Rprofile

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -3,3 +3,9 @@ options(
   blogdown.rmd = TRUE,
   blogdown.subdir = "articles"
 )
+
+rprofile <- Sys.getenv("R_PROFILE_USER", "~/.Rprofile")
+
+if (file.exists(rprofile)) {
+  source(file = rprofile)
+}


### PR DESCRIPTION
The site uses a project Rprofile, which means the user profile is not
evaluated, this change allows it to be evaluated if a user profile
exists.

This lead to some confusion on my part because my profile was not being executed until I figured out what was going on.