### PR TITLE
Remove past event.

### DIFF
--- a/data/events.yaml
+++ b/data/events.yaml
@@ -7,16 +7,6 @@ events:
   what: |
     If you see this event, something has gone wrong
 
-- url: https://events.attend.com/f/1383784975
-  title: Building Tidy Tools Workshop
-  where: Sydney, Australia
-  when:  May 1-2
-  iso8601: 2019-05-02
-  what: |
-    You should take this workshop if you have experience programming in
-    R and want to learn how to tackle larger scale problems. The class
-    is taught by Hadley Wickham, Chief Scientist at RStudio.
-
 - url: https://ww2.amstat.org/meetings/sdss/2019/onlineprogram/Program.cfm?date=05-29-19
   title: Symposium on Data Science and Statistics
   where: Bellevue WA


### PR DESCRIPTION
Remove May 1-2 Tidy Tools workshop from events.