### PR TITLE
Change default extension to `.Rmarkdown`

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -1,6 +1,6 @@
 options(
   blogdown.author = "Hadley Wickham",
-  blogdown.rmd = TRUE,
+  blogdown.ext = ".Rmarkdown",
   blogdown.subdir = "articles"
 )
 


### PR DESCRIPTION
* Change default file extension for posts to `.Rmarkdown`

cc @apreshill — is this the change as you envisioned?