### PR TITLE
Fix publish date in ggplot2 3.2.0 release post

### DIFF
--- a/content/articles/2019-03-ggplot2-3-2-0.Rmarkdown
+++ b/content/articles/2019-03-ggplot2-3-2-0.Rmarkdown
@@ -1,7 +1,7 @@
 ---
 title: 'ggplot2 3.2.0'
 author: Thomas Lin Pedersen
-date: '2019-05-20'
+date: '2019-06-16'
 slug: ggplot2-3-2-0
 description: > 
   ggplot2 3.2.0 is now on CRAN!


### PR DESCRIPTION
I forgot to update the publish date before merging. This fixes it