### PR TITLE
Add tags to rendered posts.

### DIFF
--- a/content/blog/2017-07-ggplot2-tidy-evaluation/index.markdown
+++ b/content/blog/2017-07-ggplot2-tidy-evaluation/index.markdown
@@ -4,6 +4,9 @@ date: '2018-07-24'
 slug: ggplot2-tidy-evaluation
 author: Mara Averick
 categories: [package]
+tags:
+  - ggplot2
+  - tidyverse
 description: >
   Using tidy evaluation in ggplot2 3.0.0.
 photo:

--- a/content/blog/2017-08-googledrive-initial-release/index.md
+++ b/content/blog/2017-08-googledrive-initial-release/index.md
@@ -7,10 +7,12 @@ description: >
   The first release of googledrive is now on CRAN. Operate on Google Drive files from R.
 categories:
   - package
+tags:
+  - googledrive
+  - tidyverse
 photo:
   url: https://unsplash.com/photos/wgLPy2YBXuc
   author: Paul Csogi
-tags: []
 ---
 
 We are tickled pink to announce the initial CRAN release of the [googledrive package](http://googledrive.tidyverse.org). This is a collaboration between Jenny Bryan and tidyverse intern, [Lucy D'Agostino McGowan](http://lucymcgowan.com/) (blog post on that coming soon!).

--- a/content/blog/2017-08-purrr-0.2.3/index.html
+++ b/content/blog/2017-08-purrr-0.2.3/index.html
@@ -11,6 +11,9 @@ photo:
   url: https://unsplash.com/photos/TAN1KpDS7Rg
   author: Erika Lanpher
 categories: [package]
+tags:
+  - purrr
+  - tidyverse
 ---
 
 

--- a/content/blog/2017-08-tidyr-0.7.0/index.html
+++ b/content/blog/2017-08-tidyr-0.7.0/index.html
@@ -10,6 +10,9 @@ photo:
   url: https://unsplash.com/photos/8tem2WpFPhM
   author: Radek Grzybowski
 categories: [package]
+tags:
+  - tidyr
+  - tidyverse
 ---
 
 

--- a/content/blog/2017-09-erratum-tidyr/index.html
+++ b/content/blog/2017-09-erratum-tidyr/index.html
@@ -9,6 +9,9 @@ photo:
   url: https://unsplash.com/photos/0vY082Un2pk
   author: Edu Grande
 categories: [package]
+tags:
+  - tidyr
+  - tidyverse
 ---
 
 

--- a/content/blog/2017-09-ggplot2-internship/index.html
+++ b/content/blog/2017-09-ggplot2-internship/index.html
@@ -10,6 +10,8 @@ photo:
   url: https://unsplash.com/photos/DpF8nI-dQKA
   author: Joe Shillington
 categories: [learn]
+tags:
+  - ggplot2
 ---
 
 

--- a/content/blog/2017-09-lucy-experience/index.md
+++ b/content/blog/2017-09-lucy-experience/index.md
@@ -9,6 +9,8 @@ photo:
   url: https://twitter.com/_inundata
   author: Karthik Ram
 categories: [learn]
+tags:
+  - googledrive
 ---
 
 

--- a/content/blog/2017-10-31-glue-1.2.0/index.html
+++ b/content/blog/2017-10-31-glue-1.2.0/index.html
@@ -7,6 +7,9 @@ categories: [package]
 description: >
   glue 1.2.0 is now available on CRAN. glue is designed to make it easy to
   interpolate ("glue") your data into strings.
+tags:
+  - glue
+  - tidyverse
 photo:
   url: http://www.littlerock.af.mil/News/Photos/igphoto/2001697811/
   author: Airman 1st Class Grace Nichols

--- a/content/blog/2017-11-01-lubridate-1.7.0/index.html
+++ b/content/blog/2017-11-01-lubridate-1.7.0/index.html
@@ -9,6 +9,9 @@ photo:
   url: https://unsplash.com/photos/yBzrPGLjMQw
   author: Heather Zabriskie
 categories: [package]
+tags:
+  - lubridate
+  - tidyverse
 ---
 
 

--- a/content/blog/2017-11-16-withr-2.1.0/index.html
+++ b/content/blog/2017-11-16-withr-2.1.0/index.html
@@ -4,6 +4,9 @@ date: '2017-11-16'
 slug: withr-2.1.0
 author: Jim Hester
 categories: [package]
+tags:
+  - withr
+  - r-lib
 description: >
   withr 2.1.0 is now available on CRAN.
 photo:

--- a/content/blog/2017-11-28-usethis-1-0-0/index.html
+++ b/content/blog/2017-11-28-usethis-1-0-0/index.html
@@ -5,6 +5,9 @@ date: '2017-11-28'
 slug: usethis-1.0.0
 categories:
   - package
+tags:
+  - usethis
+  - r-lib
 photo:
   url: https://unsplash.com/photos/IClZBVw5W5A
   author: Todd Quackenbush

--- a/content/blog/2017-11-tidyverse_1.2.0/index.html
+++ b/content/blog/2017-11-tidyverse_1.2.0/index.html
@@ -9,6 +9,8 @@ photo:
   url: https://pixabay.com/en/universe-sky-star-space-all-1566159/
   author: Gerd Altmann
 categories: [package]
+tags:
+  - tidyverse
 ---
 
 

--- a/content/blog/2017-12-20-styler-1-0-0/index.html
+++ b/content/blog/2017-12-20-styler-1-0-0/index.html
@@ -5,12 +5,14 @@ date: '2017-12-20'
 slug: styler-1.0.0
 categories:
   - package
+tags:
+  - r-lib
+  - styler
 photo:
   url: https://unsplash.com/photos/mpdIPhYqZ4Y
   author: Heng Films
 description: >
   styler, a package that can format your code according to the tidyverse style guide, is now on CRAN.
-
 ---
 
 

--- a/content/blog/2017-12-29-dbplyr-1-2/index.html
+++ b/content/blog/2017-12-29-dbplyr-1-2/index.html
@@ -5,7 +5,7 @@ date: '2018-01-08'
 slug: dbplyr-1-2
 categories:
   - package
-tags: [package, tidyverse, databases]
+tags: [dbplyr, tidyverse, dplyr]
 description: "New version now on CRAN. It features new database backends, an enhanced copy_to(), and initial stringr support"
 photo:
   url: https://unsplash.com/photos/y7rGTFyOzxc

--- a/content/blog/2017-12-29-dbplyr-1-2/index.html
+++ b/content/blog/2017-12-29-dbplyr-1-2/index.html
@@ -5,7 +5,7 @@ date: '2018-01-08'
 slug: dbplyr-1-2
 categories:
   - package
-tags: [dbplyr, tidyverse, dplyr]
+tags: [dbplyr, tidyverse, dplyr, databases]
 description: "New version now on CRAN. It features new database backends, an enhanced copy_to(), and initial stringr support"
 photo:
   url: https://unsplash.com/photos/y7rGTFyOzxc

--- a/content/blog/2017-12-nov-updates-2017/index.html
+++ b/content/blog/2017-12-nov-updates-2017/index.html
@@ -5,6 +5,8 @@ date: '2017-12-29'
 author: Mara Averick
 categories:
   - other
+tags:
+  - tidyverse
 photo:
   url: https://unsplash.com/photos/lPQIndZz8Mo
   author: Pablo Garcia Saldaña

--- a/content/blog/2017-12-testthat-2-0/index.html
+++ b/content/blog/2017-12-testthat-2-0/index.html
@@ -5,7 +5,7 @@ date: '2017-12-19'
 slug: testthat-2-0-0
 categories:
   - package
-tags: [package, r-lib]
+tags: [r-lib, testthat]
 photo:
   url: https://unsplash.com/photos/Lu2pfy_8VKg
   author: Cameron Kirby

--- a/content/blog/2018-01-fs-1.0.0/index.html
+++ b/content/blog/2018-01-fs-1.0.0/index.html
@@ -4,6 +4,9 @@ date: '2018-01-22'
 slug: fs-1.0.0
 author: Jim Hester
 categories: [package]
+tags:
+  - fs
+  - r-lib
 description: >
   fs 1.0.0 is now available on CRAN. fs provides a cross-platform, uniform
   interface to file system operations.

--- a/content/blog/2018-01-tibble-1-4-1/index.html
+++ b/content/blog/2018-01-tibble-1-4-1/index.html
@@ -9,6 +9,9 @@ photo:
   url: https://unsplash.com/photos/cFeRWofFkw8
   author: Patrick Schneider
 categories: [package]
+tags:
+  - tibble
+  - tidyverse
 ---
 
 

--- a/content/blog/2018-01-tibble-1-4-2/index.html
+++ b/content/blog/2018-01-tibble-1-4-2/index.html
@@ -9,6 +9,9 @@ photo:
   url: https://unsplash.com/photos/6GjHwABuci4
   author: Mikael Kristenson
 categories: [package]
+tags:
+  - tibble
+  - tidyverse
 ---
 
 

--- a/content/blog/2018-02-forcats-0-3-0/index.html
+++ b/content/blog/2018-02-forcats-0-3-0/index.html
@@ -9,6 +9,9 @@ photo:
   url: https://www.pexels.com/photo/photo-of-a-cat-sleeping-on-gray-concrete-bench-757457/
   author: Nicole Law
 categories: [package]
+tags:
+  - forcats
+  - tidyverse
 ---
 
 

--- a/content/blog/2018-02-rlang-0.2.0/index.html
+++ b/content/blog/2018-02-rlang-0.2.0/index.html
@@ -8,6 +8,9 @@ description: >
 author: Lionel Henry
 date: 2018-03-02
 categories: [package]
+tags:
+  - rlang
+  - r-lib
 photo:
   url: https://unsplash.com/photos/K5gBXHSvtkc
   author: Denise Johnson

--- a/content/blog/2018-02-stringr-1-3-0/index.html
+++ b/content/blog/2018-02-stringr-1-3-0/index.html
@@ -9,6 +9,9 @@ photo:
   url: https://unsplash.com/photos/dLTpk6N31Fc
   author: Igor Ovsyannykov
 categories: [package]
+tags:
+  - stringr
+  - tidyverse
 ---
 
 

--- a/content/blog/2018-02-tidyr-0-8-0/index.html
+++ b/content/blog/2018-02-tidyr-0-8-0/index.html
@@ -5,7 +5,9 @@ date: '2018-02-13'
 slug: tidyr-0-8-0
 categories:
   - package
-tags: []
+tags:
+  - tidyr
+  - tidyverse
 photo:
   url: https://unsplash.com/photos/byXFt2LwVac
   author: Samuel Zeller
@@ -23,9 +25,9 @@ photo:
 df %&gt;% separate(x, c(&quot;gender&quot;, &quot;number&quot;), -1)
 #&gt; # A tibble: 3 x 2
 #&gt;   gender number
-#&gt;   &lt;chr&gt;  &lt;chr&gt; 
-#&gt; 1 male   1     
-#&gt; 2 female 2     
+#&gt;   &lt;chr&gt;  &lt;chr&gt;
+#&gt; 1 male   1
+#&gt; 2 female 2
 #&gt; 3 male   2</code></pre>
 </div>
 <div id="new-features" class="section level2">
@@ -34,13 +36,13 @@ df %&gt;% separate(x, c(&quot;gender&quot;, &quot;number&quot;), -1)
 <pre class="r"><code>df &lt;- tibble(x = c(&quot;a&quot;, &quot;b&quot;, &quot;c&quot;), n = c(2, 3, 1))
 df %&gt;% uncount(n)
 #&gt; # A tibble: 6 x 1
-#&gt;   x    
+#&gt;   x
 #&gt;   &lt;chr&gt;
-#&gt; 1 a    
-#&gt; 2 a    
-#&gt; 3 b    
-#&gt; 4 b    
-#&gt; 5 b    
+#&gt; 1 a
+#&gt; 2 a
+#&gt; 3 b
+#&gt; 4 b
+#&gt; 5 b
 #&gt; 6 c</code></pre>
 <p>If you want a unique identifier for each row, use the <code>.id</code> argument:</p>
 <pre class="r"><code>df %&gt;% uncount(n, .id = &quot;id&quot;)

--- a/content/blog/2018-02-usethis-1-3-0/index.html
+++ b/content/blog/2018-02-usethis-1-3-0/index.html
@@ -7,7 +7,9 @@ author: Jenny Bryan
 date: 2018-02-25
 categories:
   - package
-tags: []
+tags:
+  - usethis
+  - r-lib
 photo:
   url: https://pixabay.com/en/tools-vintage-woodworking-saw-1209764/
   author: unknown

--- a/content/blog/2018-03-pillar-1-2-1/index.html
+++ b/content/blog/2018-03-pillar-1-2-1/index.html
@@ -12,6 +12,7 @@ photo:
 categories: [package]
 tags:
   - pillar
+  - tibble
   - r-lib
 ---
 

--- a/content/blog/2018-03-pillar-1-2-1/index.html
+++ b/content/blog/2018-03-pillar-1-2-1/index.html
@@ -10,6 +10,9 @@ photo:
   url: https://unsplash.com/photos/ZMRMFULofus
   author: Joel Filipe
 categories: [package]
+tags:
+  - pillar
+  - r-lib
 ---
 
 

--- a/content/blog/2018-04-bigrquery-1-0-0/index.html
+++ b/content/blog/2018-04-bigrquery-1-0-0/index.html
@@ -5,7 +5,9 @@ date: '2018-04-24'
 slug: bigrquery-1-0-0
 categories:
   - package
-tags: []
+tags:
+  - bigrquery
+  - dbplyr
 photo:
   url: https://unsplash.com/photos/kmAAlcld6wA
   author: Andrew Ruiz

--- a/content/blog/2018-04-bigrquery-1-0-0/index.html
+++ b/content/blog/2018-04-bigrquery-1-0-0/index.html
@@ -8,6 +8,7 @@ categories:
 tags:
   - bigrquery
   - dbplyr
+  - databases
 photo:
   url: https://unsplash.com/photos/kmAAlcld6wA
   author: Andrew Ruiz

--- a/content/blog/2018-04-pillar-1-2-2/index.html
+++ b/content/blog/2018-04-pillar-1-2-2/index.html
@@ -11,6 +11,7 @@ photo:
 categories: [package]
 tags:
   - pillar
+  - tibble
   - r-lib
 ---
 

--- a/content/blog/2018-04-pillar-1-2-2/index.html
+++ b/content/blog/2018-04-pillar-1-2-2/index.html
@@ -9,6 +9,9 @@ photo:
   url: https://unsplash.com/photos/UoWfBET-G9k
   author: Chris Barbalis
 categories: [package]
+tags:
+  - pillar
+  - r-lib
 ---
 
 

--- a/content/blog/2018-04-readxl-1-1-0/index.html
+++ b/content/blog/2018-04-readxl-1-1-0/index.html
@@ -7,6 +7,9 @@ author: Jenny Bryan
 date: 2018-04-23
 categories:
   - package
+tags:
+  - readxl
+  - tidyverse
 photo:
   url: https://twitter.com/Thoughtfulnz/status/987900521309614080
   author: David Hood

--- a/content/blog/2018-05-dplyr-0-7-5/index.html
+++ b/content/blog/2018-05-dplyr-0-7-5/index.html
@@ -9,6 +9,9 @@ photo:
   url: https://unsplash.com/photos/aqrIcYonB-o
   author: Phúc Long
 categories: [package]
+tags:
+  - dplyr
+  - tidyverse
 ---
 
 

--- a/content/blog/2018-05-ggplot2-2-3-0/index.markdown
+++ b/content/blog/2018-05-ggplot2-2-3-0/index.markdown
@@ -6,6 +6,9 @@ slug: ggplot2-2-3-0
 description: >
     What you need to know about upcoming changes for ggplot2 2.3.0.
 categories: [package]
+tags:
+  - ggplot2
+  - tidyverse
 photo:
   url: https://unsplash.com/photos/OhQhkkVJYhI
   author: chuttersnap

--- a/content/blog/2018-05-pkgdown-1-0-0/index.html
+++ b/content/blog/2018-05-pkgdown-1-0-0/index.html
@@ -4,6 +4,9 @@ author: Hadley Wickham
 date: '2018-05-03'
 slug: pkgdown-1-0-0
 categories: [package]
+tags:
+  - pkgdown
+  - r-lib
 photo:
   url: https://unsplash.com/photos/rx1iJ59jRyU
   author: Annie Spratt

--- a/content/blog/2018-06-bench-1.0.1/index.html
+++ b/content/blog/2018-06-bench-1.0.1/index.html
@@ -4,6 +4,9 @@ date: '2018-06-28'
 slug: bench-1.0.1
 author: Jim Hester
 categories: [package]
+tags:
+  - bench
+  - r-lib
 description: >
   bench 1.0.1 is now available on CRAN. bench allows you to benchmark
   code, by tracking execution time, memory allocations and garbage

--- a/content/blog/2018-06-conflicted/index.html
+++ b/content/blog/2018-06-conflicted/index.html
@@ -8,7 +8,9 @@ categories:
 photo:
   url: https://unsplash.com/photos/M03OCZvYSxY
   author: Vincent van Zalinge
-tags: []
+tags:
+  - conflicted
+  - r-lib
 ---
 
 

--- a/content/blog/2018-06-haven-1-1-2/index.html
+++ b/content/blog/2018-06-haven-1-1-2/index.html
@@ -10,7 +10,9 @@ categories:
 photo:
   url: https://unsplash.com/photos/cLKDVvtoVZo
   author: Will van Wingerden
-tags: []
+tags:
+  - haven
+  - tidyverse
 ---
 
 

--- a/content/blog/2018-06-pkgdown-1-1-0/index.html
+++ b/content/blog/2018-06-pkgdown-1-1-0/index.html
@@ -6,6 +6,9 @@ slug: pkgdown-1-1-0
 description: >
     pkgdown 1.1.0 is now on CRAN.
 categories: [package]
+tags:
+  - pkgdown
+  - r-lib
 photo:
   url: https://www.pexels.com/photo/person-s-holds-brown-gift-box-842876/
   author: Kim Stiver

--- a/content/blog/2018-06-tidyverse-not-for-packages/index.html
+++ b/content/blog/2018-06-tidyverse-not-for-packages/index.html
@@ -6,6 +6,8 @@ slug: tidyverse-not-for-packages
 description: >
     Why the tidyverse package shouldn't be in your dependencies.
 categories: [other]
+tags:
+  - tidyverse
 photo:
   url: https://unsplash.com/photos/dQLgop4tnsc
   author: Jamie Street

--- a/content/blog/2018-07-broom-0-5-0/index.markdown
+++ b/content/blog/2018-07-broom-0-5-0/index.markdown
@@ -7,6 +7,9 @@ description: >
   broom 0.5.0 is on CRAN.
 categories:
   - package
+tags:
+  - broom
+  - tidymodels
 photo:
   url: https://unsplash.com/photos/vYcH7pI6v1Q
   author: Nagesh Badu

--- a/content/blog/2018-07-ggplot2-3-0-0/index.markdown
+++ b/content/blog/2018-07-ggplot2-3-0-0/index.markdown
@@ -7,6 +7,9 @@ description: >
   ggplot2 3.0.0 is on CRAN.
 categories:
   - package
+tags:
+  - ggplot2
+  - tidyverse
 photo:
   url: https://unsplash.com/photos/wEL2zPX3jDg
   author: Fabio Ballasina

--- a/content/blog/2018-08-ggplot2-community-posts/index.markdown
+++ b/content/blog/2018-08-ggplot2-community-posts/index.markdown
@@ -5,6 +5,9 @@ date: '2018-08-09'
 slug: ggplot2-community-posts
 categories:
   - other
+tags:
+  - ggplot2
+  - tidyverse
 description: >
   Blog posts from the community using ggplot2 3.0.0.
 photo:

--- a/content/blog/2018-08-roxygen2-6-1-0/index.markdown
+++ b/content/blog/2018-08-roxygen2-6-1-0/index.markdown
@@ -4,6 +4,9 @@ date: 2018-08-07
 slug: roxygen2-6-1-0
 author: Mara Averick
 categories: [package]
+tags:
+  - roxygen2
+  - r-lib
 description: >
     roxygen2 6.1.0 is now on CRAN!
 photo:

--- a/content/blog/2018-08-scales-1-0-0/index.markdown
+++ b/content/blog/2018-08-scales-1-0-0/index.markdown
@@ -12,6 +12,7 @@ photo:
   author: Ricardo Gomez Angel
 tags:
   - scales
+  - ggplot2
   - r-lib
 ---
 

--- a/content/blog/2018-08-scales-1-0-0/index.markdown
+++ b/content/blog/2018-08-scales-1-0-0/index.markdown
@@ -10,7 +10,9 @@ categories:
 photo:
   url: https://unsplash.com/photos/3kzlCL3rj8A
   author: Ricardo Gomez Angel
-tags: []
+tags:
+  - scales
+  - r-lib
 ---
 
 

--- a/content/blog/2018-08-tidymodels/index.markdown
+++ b/content/blog/2018-08-tidymodels/index.markdown
@@ -7,6 +7,8 @@ description: >
   tidymodels 0.0.1 is on CRAN.
 categories:
   - package
+tags:
+  - tidymodels
 photo:
   url: https://github.com/tidymodels
   author: tidymodels

--- a/content/blog/2018-09-processx-3.2.0/index.markdown
+++ b/content/blog/2018-09-processx-3.2.0/index.markdown
@@ -4,6 +4,9 @@ date: 2018-09-06
 slug: processx-3.2.0
 author: Gábor Csárdi
 categories: [package]
+tags:
+  - processx
+  - r-lib
 description: >
     Run external processes with processx
 photo:

--- a/content/blog/2018-10-devtools-2.0.0/index.markdown
+++ b/content/blog/2018-10-devtools-2.0.0/index.markdown
@@ -4,6 +4,9 @@ date: 2018-10-30
 slug: devtools-2-0-0
 author: Jim Hester
 categories: [package]
+tags:
+  - devtools
+  - r-lib
 description: >
     Make package development easier by providing R functions that simplify and expedite common tasks.
 photo:

--- a/content/blog/2018-10-ggplot2-3-1-0/index.markdown
+++ b/content/blog/2018-10-ggplot2-3-1-0/index.markdown
@@ -7,6 +7,9 @@ description: >
   ggplot2 3.1.0 is now on CRAN!
 categories:
   - package
+tags:
+  - ggplot2
+  - tidyverse
 photo:
   url: https://unsplash.com/photos/Ibq4B5iE_-4
   author: Stephan Henning

--- a/content/blog/2018-10-rlang-0-3-0/index.markdown
+++ b/content/blog/2018-10-rlang-0-3-0/index.markdown
@@ -4,6 +4,9 @@ date: 2018-10-29
 slug: rlang-0-3-0
 author: Lionel Henry
 categories: [package]
+tags:
+  - rlang
+  - r-lib
 description: >
     API for working with tidy evaluation, base R types, and errors
 photo:

--- a/content/blog/2018-11-generics-0.0.1/index.markdown
+++ b/content/blog/2018-11-generics-0.0.1/index.markdown
@@ -4,6 +4,9 @@ date: 2018-11-14
 slug: generics-0.0.1
 author: Max Kuhn, Davis Vaughan
 categories: [package]
+tags:
+  - generics
+  - r-lib
 description: >
     Reduce package dependencies by using common lightweight S3 generics.
 photo:

--- a/content/blog/2018-11-parsnip-0-0-1/index.markdown
+++ b/content/blog/2018-11-parsnip-0-0-1/index.markdown
@@ -4,6 +4,9 @@ date: 2018-11-28
 slug: parsnip-0-0-1
 author: Max Kuhn
 categories: [package]
+tags:
+  - parsnip
+  - tidymodels
 description: >
     A tidy unified interface to models
 photo:

--- a/content/blog/2018-11-tibble-2.0.0-pre-announce/index.markdown
+++ b/content/blog/2018-11-tibble-2.0.0-pre-announce/index.markdown
@@ -4,6 +4,9 @@ date: 2018-11-28
 slug: tibble-2.0.0-pre-announce
 author: Kirill Müller, Jenny Bryan
 categories: [package]
+tags:
+  - tibble
+  - tidyverse
 description: >
     The upcoming tibble 2.0.0 release has internal changes relevant to package developers who depend on tibble.
 photo:

--- a/content/blog/2018-11-tidymodels-updates/index.markdown
+++ b/content/blog/2018-11-tidymodels-updates/index.markdown
@@ -4,6 +4,12 @@ date: 2018-11-29
 slug: tidymodels-update-nov-18
 author: Max Kuhn, Davis Vaughan, Alex Hayes
 categories: [package]
+tags:
+  - recipes
+  - yardstick
+  - embed
+  - tidyposterior
+  - tidymodels
 description: >
     A variety of updates for tidymodels packages.
 photo:

--- a/content/blog/2018-12-14-tidyverse-and-r-lib-year-in-review/index.Rmarkdown
+++ b/content/blog/2018-12-14-tidyverse-and-r-lib-year-in-review/index.Rmarkdown
@@ -7,6 +7,9 @@ description: >
   A look back on 2018 in the tidyverse and beyond.
 categories:
   - other
+tags:
+  - r-lib
+  - tidyverse
 photo:
   url: https://unsplash.com/photos/SshYpuf607g
   author: Aperture Vintage

--- a/content/blog/2018-12-14-tidyverse-and-r-lib-year-in-review/index.markdown
+++ b/content/blog/2018-12-14-tidyverse-and-r-lib-year-in-review/index.markdown
@@ -7,6 +7,9 @@ description: >
   A look back on 2018 in the tidyverse and beyond.
 categories:
   - other
+tags:
+  - r-lib
+  - tidyverse
 photo:
   url: https://unsplash.com/photos/SshYpuf607g
   author: Aperture Vintage

--- a/content/blog/2018-12-httr-1-4-0/index.markdown
+++ b/content/blog/2018-12-httr-1-4-0/index.markdown
@@ -10,6 +10,9 @@ photo:
   author: Chris Yang
 categories:
   - package
+tags:
+  - httr
+  - r-lib
 ---
 
 We're well pleased to announce the release of [httr](https://httr.r-lib.org/) 1.4.0. The goal of httr is to provide a wrapper for the [curl](https://CRAN.R-project.org/package=curl) package, customised to the demands of modern web APIs.

--- a/content/blog/2018-12-lobstr/index.markdown
+++ b/content/blog/2018-12-lobstr/index.markdown
@@ -7,6 +7,9 @@ description: >
   lobstr is now on CRAN. lobstr provides tools that allow you to dig into the detail of an object.
 categories:
   - package
+tags:
+  - lobstr
+  - r-lib
 photo:
   url: https://unsplash.com/photos/BmjuEqM4YOY
   author: Toa Heftiba

--- a/content/blog/2018-12-pkgdown-1-3-0/index.markdown
+++ b/content/blog/2018-12-pkgdown-1-3-0/index.markdown
@@ -7,6 +7,9 @@ description: >
   pkgdown 1.3.0 is now on CRAN!
 categories:
   - package
+tags:
+  - pkgdown
+  - r-lib
 photo:
   url: https://pixabay.com/en/decoration-packages-gifts-ribbons-3229259/
   author: jackmac34

--- a/content/blog/2018-12-readr-1.3.1/index.markdown
+++ b/content/blog/2018-12-readr-1.3.1/index.markdown
@@ -10,6 +10,9 @@ photo:
   author: Anastasia Zhenina
 categories:
   - package
+tags:
+  - readr
+  - tidyverse
 ---
 
 

--- a/content/blog/2018-12-readxl-1-2-0/index.markdown
+++ b/content/blog/2018-12-readxl-1-2-0/index.markdown
@@ -10,6 +10,9 @@ photo:
   author: David Hood
 categories:
   - package
+tags:
+  - readxl
+  - tidyverse
 ---
 
 

--- a/content/blog/2018-12-textrecipes-0-0-1/index.markdown
+++ b/content/blog/2018-12-textrecipes-0-0-1/index.markdown
@@ -7,6 +7,9 @@ description: >
     textrecipes 0.0.1 is now on CRAN!
 categories:
   - package
+tags:
+  - textrecipes
+  - tidymodels
 photo:
   url: https://unsplash.com/photos/X1exjxxBho4
   author: Roman Kraft
@@ -28,8 +31,8 @@ install.packages("textrecipes")
 The steps introduced here can be split into 3 types, those that:
 
 1. convert from characters to list-columns and vice versa,
-1. modify the elements in list-columns, and
-1. convert list-columns to numerics.
+2. modify the elements in list-columns, and
+3. convert list-columns to numerics.
 
 This allows for greater flexibility in the preprocessing tasks that can be done while staying inside the [recipes](https://github.com/tidymodels/recipes) framework. This also prevents having a single step with many arguments.
 

--- a/content/blog/2019-01-dbplyr-1-3-0/index.markdown
+++ b/content/blog/2019-01-dbplyr-1-3-0/index.markdown
@@ -7,6 +7,10 @@ description: >
   dbplyr 1.3.0 is now on CRAN.
 categories:
   - package
+tags:
+  - dbplyr
+  - dplyr
+  - tidyverse
 photo:
   url: https://unsplash.com/photos/sk59I1qRfEM
   author: Scott Webb

--- a/content/blog/2019-01-haven-2-0-0/index.html
+++ b/content/blog/2019-01-haven-2-0-0/index.html
@@ -7,6 +7,9 @@ description: >
   haven 2.0.0 is now on CRAN.
 categories:
   - package
+tags:
+  - haven
+  - tidyverse
 photo:
   url: https://unsplash.com/photos/D5OzyJ71mLI
   author: Robert Wiedemann

--- a/content/blog/2019-01-rlang-0-3-1/index.html
+++ b/content/blog/2019-01-rlang-0-3-1/index.html
@@ -7,6 +7,9 @@ description: >
   rlang 0.3.1 is now on CRAN.
 categories:
   - package
+tags:
+  - rlang
+  - r-lib
 photo:
   url: https://unsplash.com/photos/FhdN5QVrBfY
   author: Eberhard Grossgasteiger

--- a/content/blog/2019-01-tibble-2-0-1/index.markdown
+++ b/content/blog/2019-01-tibble-2-0-1/index.markdown
@@ -9,6 +9,9 @@ photo:
   url: https://unsplash.com/photos/KA89yJKYtjE
   author: Marcello Gennari
 categories: [package]
+tags:
+  - tibble
+  - tidyverse
 ---
 
 

--- a/content/blog/2019-01-vdiffr-0-3-0/index.html
+++ b/content/blog/2019-01-vdiffr-0-3-0/index.html
@@ -7,6 +7,8 @@ description: >
   vdiffr 0.3.0 is now on CRAN.
 categories:
   - package
+tags:
+  - vdiffr
 photo:
   url: https://unsplash.com/photos/jHjjWSmnznc
   author: Jakob Owens

--- a/content/blog/2019-02-bigrquery-1-1-0/index.markdown
+++ b/content/blog/2019-02-bigrquery-1-1-0/index.markdown
@@ -7,6 +7,11 @@ description: >
   bigrquery 1.1.0 is now on CRAN.
 categories:
   - package
+tags:
+  - bigrquery
+  - dplyr
+  - dbplyr
+  - databases
 photo:
   url: https://www.pexels.com/photo/green-and-red-abstract-painting-1070534/
   author: Steve Johnson

--- a/content/blog/2019-02-dplyr-0-8-0/index.markdown
+++ b/content/blog/2019-02-dplyr-0-8-0/index.markdown
@@ -10,7 +10,6 @@ categories:
 tags:
   - dplyr
   - tidyverse
-  - package
 photo:
   url: https://unsplash.com/photos/-WAiyQLGEEc
   author: Element5 Digital

--- a/content/blog/2019-02-haven-2-1-0/index.markdown
+++ b/content/blog/2019-02-haven-2-1-0/index.markdown
@@ -7,6 +7,9 @@ description: >
   haven 2.1.0 is now on CRAN!
 categories:
   - package
+tags:
+  - haven
+  - tidyverse
 photo:
   url: https://www.pexels.com/photo/beach-lighthouse-3491/
   author: Skitterphoto

--- a/content/blog/2019-02-purrr-0-3-0/index.html
+++ b/content/blog/2019-02-purrr-0-3-0/index.html
@@ -7,6 +7,9 @@ description: >
   purrr 0.3.0 is now on CRAN.
 categories:
   - package
+tags:
+  - purrr
+  - tidyverse
 photo:
   url: https://unsplash.com/photos/NodtnCsLdTE
   author: Mikhail Vasilyev

--- a/content/blog/2019-02-stringr-1-4-0/index.markdown
+++ b/content/blog/2019-02-stringr-1-4-0/index.markdown
@@ -7,6 +7,9 @@ description: >
     stringr 1.4.0 is now on CRAN!
 categories:
   - package
+tags:
+  - stringr
+  - tidyverse
 photo:
   url: https://unsplash.com/photos/o-d37kiKqqc
   author: Maranda Vandergriff

--- a/content/blog/2019-03-ggplot2-3-2-0/index.markdown
+++ b/content/blog/2019-03-ggplot2-3-2-0/index.markdown
@@ -7,6 +7,9 @@ description: >
   ggplot2 3.2.0 is now on CRAN!
 categories:
   - package
+tags:
+  - ggplot2
+  - tidyverse
 photo:
   url: https://unsplash.com/photos/eH_ftJYhaTY
   author: chuttersnap

--- a/content/blog/2019-03-tibble-2-1-1/index.markdown
+++ b/content/blog/2019-03-tibble-2-1-1/index.markdown
@@ -9,6 +9,9 @@ photo:
   url: https://unsplash.com/photos/yaiy4mCbzw0
   author: Ganapathy Kumar
 categories: [package]
+tags:
+  - tibble
+  - tidyverse
 ---
 
 

--- a/content/blog/2019-04-dbplyr-1-4-0/index.markdown
+++ b/content/blog/2019-04-dbplyr-1-4-0/index.markdown
@@ -6,6 +6,8 @@ slug: dbplyr-1-4-0
 categories:
   - package
 tags:
+  - dbplyr
+  - dplyr
   - databases
 photo:
   url: https://unsplash.com/photos/JuFcQxgCXwA

--- a/content/blog/2019-04-parsnip-internals/index.markdown
+++ b/content/blog/2019-04-parsnip-internals/index.markdown
@@ -10,6 +10,9 @@ photo:
   url: https://unsplash.com/photos/wRoyrBjSBzM
 slug: parsnip-internals
 categories: [package]
+tags:
+  - parsnip
+  - tidymodels
 ---
 
 

--- a/content/blog/2019-04-testthat-2-1-0/index.markdown
+++ b/content/blog/2019-04-testthat-2-1-0/index.markdown
@@ -7,7 +7,7 @@ description: Highlights include that `context()` is now optional, and
   new `expect_invisible()` and `expect_mapequal()` expectations.
 categories:
   - package
-tags: [package, r-lib]
+tags: [testthat, r-lib]
 photo:
   url: https://www.pexels.com/photo/38070/
   author: Skitterphoto

--- a/content/blog/2019-04-usethis-1-5-0/index.markdown
+++ b/content/blog/2019-04-usethis-1-5-0/index.markdown
@@ -9,6 +9,9 @@ photo:
   url: https://unsplash.com/photos/MPu7kSboG8E
   author: Philip Veater
 categories: [package]
+tags:
+  - usethis
+  - r-lib
 ---
 
 

--- a/content/blog/2019-05-dplyr-0-8-1/index.markdown
+++ b/content/blog/2019-05-dplyr-0-8-1/index.markdown
@@ -8,6 +8,9 @@ date: '2019-05-17'
 categories: [package]
 tags:
   - dplyr
+  - tidyverse
+tags:
+  - dplyr
 photo:
   url: https://unsplash.com/photos/BiZ-_6kNjbI
   author: Sophie Elvis

--- a/content/blog/2019-05-forcats-0-4-0/index.markdown
+++ b/content/blog/2019-05-forcats-0-4-0/index.markdown
@@ -7,6 +7,9 @@ description: >
   What's new in forcats 0.4.0?
 categories:
   - package
+tags:
+  - forcats
+  - tidyverse
 photo:
   url: https://www.pexels.com/photo/close-up-photo-of-a-hand-holding-three-white-kittens-1643456/
   author: Peng Louis

--- a/content/blog/2019-05-itdepends/index.markdown
+++ b/content/blog/2019-05-itdepends/index.markdown
@@ -9,6 +9,9 @@ photo:
   url: https://unsplash.com/photos/24bzOuENxHc
   author: Ariana Prestes
 categories: [programming]
+tags:
+  - itdepends
+  - r-lib
 ---
 
 

--- a/content/blog/2019-05-resource-cleanup-in-c-and-the-r-api/index.html
+++ b/content/blog/2019-05-resource-cleanup-in-c-and-the-r-api/index.html
@@ -4,6 +4,9 @@ date: '2019-05-22'
 slug: resource-cleanup-in-c-and-the-r-api
 author: Gábor Csárdi, Lionel Henry
 categories: [package, programming]
+tags:
+  - cleancall
+  - r-lib
 description: >
     How to avoid resource leaks in C code in R packages?
     Introducing the cleancall package.

--- a/content/blog/2019-05-vroom-1-0-0/index.markdown
+++ b/content/blog/2019-05-vroom-1-0-0/index.markdown
@@ -6,7 +6,7 @@ slug: vroom-1-0-0
 description: Introducing the vroom package, extremely fast data import in R.
 categories:
   - package
-tags: [package, r-lib]
+tags: [vroom, r-lib]
 photo:
   url: https://www.pexels.com/photo/12801/
   author: Chris Peeters

--- a/content/blog/2019-06-26-ragg-0-1-0/index.markdown
+++ b/content/blog/2019-06-26-ragg-0-1-0/index.markdown
@@ -9,6 +9,7 @@ categories:
   - package
 tags:
   - r-lib
+  - ragg
 photo:
   url: https://unsplash.com/photos/sBkK2VWV8Kw
   author: Gordon Williams

--- a/content/blog/2019-06-dplyr-0-8-2/index.markdown
+++ b/content/blog/2019-06-dplyr-0-8-2/index.markdown
@@ -8,6 +8,7 @@ date: '2019-06-29'
 categories: [package]
 tags:
   - dplyr
+  - tidyverse
 photo:
   url: https://unsplash.com/photos/xFTNsGW1isI
   author: Joanna Kosinska

--- a/content/blog/2019-06-rlang-0-4-0/index.markdown
+++ b/content/blog/2019-06-rlang-0-4-0/index.markdown
@@ -7,6 +7,9 @@ description: >
   rlang 0.4.0 is now on CRAN!
 categories:
   - package
+tags:
+  - rlang
+  - r-lib
 photo:
   url: https://unsplash.com/photos/ar7ZWQ-r87g
   author: Caitlin Wynne

--- a/content/blog/2019-07-callr-3-3-0/index.html
+++ b/content/blog/2019-07-callr-3-3-0/index.html
@@ -7,6 +7,9 @@ description: >
   callr 3.3.0 is now on CRAN
 categories:
 - package
+tags:
+  - callr
+  - r-lib
 photo:
   url: https://pixabay.com/photos/venus-flytrap-carnivorous-plant-1531345
   author: MonikaP

--- a/content/blog/2019-07-dplyr-0-8-3/index.markdown
+++ b/content/blog/2019-07-dplyr-0-8-3/index.markdown
@@ -8,6 +8,7 @@ date: '2019-07-04'
 categories: [package]
 tags:
   - dplyr
+  - tidyverse
 photo:
   url: https://unsplash.com/photos/OxK32aLJXWU
   author: Krzysztof Niewolny

--- a/content/blog/2019-08-gargle-hello-world/index.markdown
+++ b/content/blog/2019-08-gargle-hello-world/index.markdown
@@ -8,6 +8,7 @@ date: '2019-08-20'
 categories: [package]
 tags:
   - gargle
+  - r-lib
 photo:
   url: https://flic.kr/p/oe2LJ1
   author: North Carolina Christian advocate (1894)

--- a/content/blog/2019-08-gmailr-1-0-0/index.markdown
+++ b/content/blog/2019-08-gmailr-1-0-0/index.markdown
@@ -8,6 +8,7 @@ date: '2019-08-26'
 categories: [package]
 tags:
   - gmailr
+  - r-lib
 photo:
   url: https://unsplash.com/photos/fb7yNPbT0l8
   author: Mathyas Kurmann

--- a/content/blog/2019-08-googledrive-1-0-0/index.markdown
+++ b/content/blog/2019-08-googledrive-1-0-0/index.markdown
@@ -8,6 +8,7 @@ date: '2019-08-20'
 categories: [package]
 tags:
   - googledrive
+  - tidyverse
 photo:
   url: https://unsplash.com/photos/8EzNkvLQosk
   author: Maarten van den Heuvel

--- a/content/blog/2019-09-callr-task-q/index.html
+++ b/content/blog/2019-09-callr-task-q/index.html
@@ -9,6 +9,9 @@ description: >
 categories:
 - programming
 - deep-dive
+tags:
+  - callr
+  - r-lib
 photo:
   url: https://unsplash.com/photos/cDwZ40Lj9eo
   author: Davide Ragusa

--- a/content/blog/2019-09-devtools-2.2.1/index.markdown
+++ b/content/blog/2019-09-devtools-2.2.1/index.markdown
@@ -4,6 +4,9 @@ date: 2019-09-26
 slug: devtools-2-2-1
 author: Jim Hester
 categories: [package]
+tags:
+  - devtools
+  - r-lib
 description: >
     Make package development easier by providing R functions that simplify and expedite common tasks.
 photo:

--- a/content/blog/2019-09-pkgdown-1-4-0/index.markdown
+++ b/content/blog/2019-09-pkgdown-1-4-0/index.markdown
@@ -10,6 +10,7 @@ categories:
   - package
 tags:
   - pkgdown
+  - r-lib
 ---
 
 We're happy to announce that [pkgdown](https://pkgdown.r-lib.org/) 1.4.0 is now

--- a/content/blog/2019-09-tidymodels/index.markdown
+++ b/content/blog/2019-09-tidymodels/index.markdown
@@ -7,6 +7,13 @@ date: '2019-09-05'
 categories: [package]
 tags:
   - tidymodels
+  - recipes
+  - embed
+  - rsample
+  - parsnip
+  - corrr
+  - tidypredict
+  - yardstick
 photo:
   url: https://unsplash.com/photos/rqIfy1UyIzE
   author: Branden Harvey

--- a/content/blog/2019-09-tidyr-1-0-0/index.markdown
+++ b/content/blog/2019-09-tidyr-1-0-0/index.markdown
@@ -7,6 +7,7 @@ categories:
   - package
 tags:
   - tidyr
+  - tidyverse
 photo:
   url: https://unsplash.com/photos/0yL6nXhn0pI
   author: Victor Garcia

--- a/content/blog/2019-10-dials-0-0-3/index.markdown
+++ b/content/blog/2019-10-dials-0-0-3/index.markdown
@@ -4,6 +4,9 @@ date: 2019-10-01
 slug: dials-0-0-3
 author: Max Kuhn
 categories: [package]
+tags:
+  - dials
+  - tidymodels
 description: >
     A major update to the tuning parameter package. 
 photo:

--- a/content/blog/2019-10-discrim-0-01/index.markdown
+++ b/content/blog/2019-10-discrim-0-01/index.markdown
@@ -4,6 +4,9 @@ date: 2019-10-17
 slug: discrim-0-0-1
 author: Max Kuhn
 categories: [package]
+tags:
+  - discrim
+  - tidymodels
 description: >
     The first version of discrim (0.0.1) is on CRAN. 
 photo:

--- a/content/blog/2019-11-dtplyr-1-0-0/index.Rmarkdown
+++ b/content/blog/2019-11-dtplyr-1-0-0/index.Rmarkdown
@@ -11,7 +11,7 @@ categories:
 tags:
   - dtplyr
   - dplyr
-  - tidverse
+  - tidyverse
 photo:
   url: https://unsplash.com/photos/h13Y8vyIXNU
   author: Jay Ruzesky

--- a/content/blog/2019-11-dtplyr-1-0-0/index.markdown
+++ b/content/blog/2019-11-dtplyr-1-0-0/index.markdown
@@ -11,7 +11,7 @@ categories:
 tags:
   - dtplyr
   - dplyr
-  - tidverse
+  - tidyverse
 photo:
   url: https://unsplash.com/photos/h13Y8vyIXNU
   author: Jay Ruzesky

--- a/content/blog/2019-11-styler-1-2-0/index.markdown
+++ b/content/blog/2019-11-styler-1-2-0/index.markdown
@@ -9,6 +9,9 @@ photo:
   url: https://unsplash.com/photos/mpdIPhYqZ4Y
 slug: styler-1-2-0
 categories: ["package"]
+tags:
+  - styler
+  - r-lib
 ---
 
 


### PR DESCRIPTION
Tags added to all past _rendered_ posts (i.e. html or markdown) indicating which package and which organization.

Going forward, tags will be in the source files.