### PR TITLE
update the base hugo theme to fix blog and non-blog post sharing images

### DIFF
--- a/themes/hugo-tourmaline/layouts/partials/meta.html
+++ b/themes/hugo-tourmaline/layouts/partials/meta.html
@@ -9,27 +9,30 @@
 {{- end -}}
 {{ hugo.Generator }}
 
-{{- if .IsHome -}}
-<title>{{ .Site.Title }}</title>
-<meta property="og:title" content="{{ .Site.Title }}">
-<meta property="og:type" content="website">
-<meta property="description" content="{{ .Site.Params.description }}">
-<meta property="og:description" content="{{ .Site.Params.description }}">
-{{ $twitter_card := "summary_large_image" }}
-  <meta property="twitter:card" content="{{ $twitter_card }}">
-{{ $twitter_image := "" }}
-{{ $twitter_image = printf "images/%s" .Site.Params.twitter_image | absURL }}
-{{- with $twitter_image -}}
-  <meta name="twitter:image" content="{{ . }}" >
-{{- end -}}
-
+{{- if or .IsHome (not (eq .Section "blog")) -}}
+  <title>{{ .Site.Title }}</title>
+  <meta property="og:title" content="{{ .Site.Title }}">
+  <meta property="og:type" content="website">
+  <meta property="description" content="{{ .Site.Params.description }}">
+  <meta property="og:description" content="{{ .Site.Params.description }}">
+  {{ $twitter_card := "summary_large_image" }}
+    <meta property="twitter:card" content="{{ $twitter_card }}">
+  {{ $twitter_image := "" }}
+  {{ $twitter_image = printf "images/%s" .Site.Params.sharing_image | absURL }}
+  {{- with $twitter_image -}}
+    <meta name="twitter:image" content="{{ . }}" >
+  {{- end -}}
 
 {{- else -}}
-<title>{{ .Title }}{{ with .Params.subtitle }} - {{ . }} {{ end }} - {{ .Site.Title }}</title>
-<meta property="og:title" content="{{ .Title }} - {{ .Site.Title }}">
-<meta property="og:type" content="article">
-<meta name="twitter:card" content="summary">
-<meta name="twitter:image" content="https://www.tidyverse.org/articles/{{ .Params.slug }}-sq.jpg" >
-<meta property="description" content="{{ .Params.description }}">
-<meta property="og:description" content="{{ .Params.description }}">
+  <title>{{ .Title }}{{ with .Params.subtitle }} - {{ . }} {{ end }} - {{ .Site.Title }}</title>
+  <meta property="og:title" content="{{ .Title }} - {{ .Site.Title }}">
+  <meta property="og:type" content="article">
+  <meta name="twitter:card" content="summary">
+  {{ $thumbnail := (.Resources.ByType "image").GetMatch "*-sq*" }}
+  {{ if $thumbnail }}
+    <meta name="twitter:image" content="{{ $thumbnail.Permalink }}" >
+  {{ end }}
+  <meta property="description" content="{{ .Params.description }}">
+  <meta property="og:description" content="{{ .Params.description }}">
+
 {{- end }}


### PR DESCRIPTION
The home page and all non-blog post pages should use a large summary card:

https://www.tidyverse.org/images/tidyverse-default.png

Blog posts should use the `*-sq*` image within the bundle.

@batpigandme 