### PR TITLE
Add `-s` flag to scheduled build.

### DIFF
--- a/.github/workflows/scheduled_build.yml
+++ b/.github/workflows/scheduled_build.yml
@@ -9,6 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Trigger build hook on Netlify
-      run: curl -X POST "https://api.netlify.com/build_hooks/${TOKEN}"
+      run: curl -X POST -d "https://api.netlify.com/build_hooks/${TOKEN}"
       env:
         TOKEN: ${{ secrets.NETLIFY_CRON_BUILD }}

--- a/.github/workflows/scheduled_build.yml
+++ b/.github/workflows/scheduled_build.yml
@@ -9,6 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Trigger build hook on Netlify
-      run: curl -X POST -d "https://api.netlify.com/build_hooks/${TOKEN}"
+      run: curl -X POST -s "https://api.netlify.com/build_hooks/${TOKEN}"
       env:
         TOKEN: ${{ secrets.NETLIFY_CRON_BUILD }}


### PR DESCRIPTION
After looking at the past two nights builds (click **Actions** in the top menu to see), I'm not sure the build hook is actually _doing_ anything. 

I've been following the two posts (below), and I _think_ adding the `-d` flag should fix it, but, @jimhester, if you could take a look, I'd appreciate it!

https://ericjinks.com/blog/2019/netlify-scheduled-build/

https://www.voorhoede.nl/en/blog/scheduling-netlify-deploys-with-github-actions/

cc @apreshill — I tried to see what you're doing on the education site, but it doesn't look like there's an Actions tab.