### PR TITLE
Add text to image links in footer

### DIFF
--- a/themes/hugo-tourmaline/layouts/partials/footer.html
+++ b/themes/hugo-tourmaline/layouts/partials/footer.html
@@ -5,12 +5,12 @@
               {{ with .Param "footer.copyright" }}{{ replace . "{year}" now.Year | markdownify}}{{ end }}<br>
               {{ end }}
               {{ if .Param "footer.support" }}
-              {{ with .Param "footer.support" }}{{ replace . "{year}" now.Year | markdownify}}{{ end }} <a class="rstudioLogo" href="https://www.rstudio.com/" title="RStudio Homepage"></a>
+              {{ with .Param "footer.support" }}{{ replace . "{year}" now.Year | markdownify}}{{ end }} <a class="rstudioLogo" href="https://www.rstudio.com/" title="RStudio Homepage" aria-label="RStudio Homepage"></a>
               {{ end }}
             </div>
             <div id="logos">
-              <a href="{{ .Param "footer.github_url" }}" title="Tidyverse GitHub organization" class="footerLogo gitHub"></a>
-              <a href="{{ .Param "footer.twitter_url" }}" title="rstats hashtag on twitter.com" class="footerLogo twitter"></a>
+              <a href="{{ .Param "footer.github_url" }}" title="Tidyverse GitHub organization" class="footerLogo gitHub" aria-label="Tidyverse GitHub organization"></a>
+              <a href="{{ .Param "footer.twitter_url" }}" title="rstats hashtag on twitter.com" class="footerLogo twitter" aria-label="rstats hashtag on twitter.com"></a>
             </div>
           </div>
         </div>

--- a/themes/hugo-tourmaline/layouts/partials/footer.html
+++ b/themes/hugo-tourmaline/layouts/partials/footer.html
@@ -10,7 +10,7 @@
             </div>
             <div id="logos">
               <a href="{{ .Param "footer.github_url" }}" class="footerLogo gitHub" aria-label="Tidyverse GitHub organization"></a>
-              <a href="{{ .Param "footer.twitter_url" }}" title="rstats hashtag on twitter.com" class="footerLogo twitter" aria-label="rstats hashtag on twitter.com"></a>
+              <a href="{{ .Param "footer.twitter_url" }}" class="footerLogo twitter" aria-label="rstats hashtag on twitter.com"></a>
             </div>
           </div>
         </div>

--- a/themes/hugo-tourmaline/layouts/partials/footer.html
+++ b/themes/hugo-tourmaline/layouts/partials/footer.html
@@ -9,7 +9,7 @@
               {{ end }}
             </div>
             <div id="logos">
-              <a href="{{ .Param "footer.github_url" }}" title="Tidyverse GitHub organization" class="footerLogo gitHub" aria-label="Tidyverse GitHub organization"></a>
+              <a href="{{ .Param "footer.github_url" }}" class="footerLogo gitHub" aria-label="Tidyverse GitHub organization"></a>
               <a href="{{ .Param "footer.twitter_url" }}" title="rstats hashtag on twitter.com" class="footerLogo twitter" aria-label="rstats hashtag on twitter.com"></a>
             </div>
           </div>

--- a/themes/hugo-tourmaline/layouts/partials/footer.html
+++ b/themes/hugo-tourmaline/layouts/partials/footer.html
@@ -5,7 +5,7 @@
               {{ with .Param "footer.copyright" }}{{ replace . "{year}" now.Year | markdownify}}{{ end }}<br>
               {{ end }}
               {{ if .Param "footer.support" }}
-              {{ with .Param "footer.support" }}{{ replace . "{year}" now.Year | markdownify}}{{ end }} <a class="rstudioLogo" href="https://www.rstudio.com/" title="RStudio Homepage" aria-label="RStudio Homepage"></a>
+              {{ with .Param "footer.support" }}{{ replace . "{year}" now.Year | markdownify}}{{ end }} <a class="rstudioLogo" href="https://www.rstudio.com/" aria-label="RStudio Homepage"></a>
               {{ end }}
             </div>
             <div id="logos">

--- a/themes/hugo-tourmaline/layouts/partials/footer.html
+++ b/themes/hugo-tourmaline/layouts/partials/footer.html
@@ -5,12 +5,12 @@
               {{ with .Param "footer.copyright" }}{{ replace . "{year}" now.Year | markdownify}}{{ end }}<br>
               {{ end }}
               {{ if .Param "footer.support" }}
-              {{ with .Param "footer.support" }}{{ replace . "{year}" now.Year | markdownify}}{{ end }} <a class="rstudioLogo" href="https://www.rstudio.com/"></a>
+              {{ with .Param "footer.support" }}{{ replace . "{year}" now.Year | markdownify}}{{ end }} <a class="rstudioLogo" href="https://www.rstudio.com/" title="RStudio Homepage"></a>
               {{ end }}
             </div>
             <div id="logos">
-              <a href="{{ .Param "footer.github_url" }}" class="footerLogo gitHub"></a>
-              <a href="{{ .Param "footer.twitter_url" }}" class="footerLogo twitter"></a>
+              <a href="{{ .Param "footer.github_url" }}" title="Tidyverse GitHub organization" class="footerLogo gitHub"></a>
+              <a href="{{ .Param "footer.twitter_url" }}" title="rstats hashtag on twitter.com" class="footerLogo twitter"></a>
             </div>
           </div>
         </div>


### PR DESCRIPTION
* Adds title for RStudio homepage, tidyverse organization on GitHub, and rstats hashtag feed on Twitter

Should fix accessibility errors in footer (part of #374). [Current page](https://wave.webaim.org/report#/https://www.tidyverse.org/blog/) vs [with this PR](https://wave.webaim.org/report#/https://deploy-preview-414--tidyverse-org.netlify.app/blog/)