### PR TITLE
Fix link in dplyr 1.0.0 across post

### DIFF
--- a/content/blog/2020-04-dplyr-1-0-0-colwise/index.Rmarkdown
+++ b/content/blog/2020-04-dplyr-1-0-0-colwise/index.Rmarkdown
@@ -48,7 +48,7 @@ df %>%
   summarise(a = mean(a), b = mean(b), c = mean(c), d = mean(c))
 ```
 
-You can now rewrite such code using `across()`, which lets you apply a transformation to multiple variables selected with the same syntax as [`select()` and `rename()`]( [tidy selection](https://www.tidyverse.org/blog/2020/03/dplyr-1-0-0-select-rename-relocate/#select-and-renaming)):
+You can now rewrite such code using `across()`, which lets you apply a transformation to multiple variables selected with the same syntax as [`select()` and `rename()`](https://www.tidyverse.org/blog/2020/03/dplyr-1-0-0-select-rename-relocate/#select-and-renaming):
 
 ```{r, eval = FALSE}
 df %>% 

--- a/content/blog/2020-04-dplyr-1-0-0-colwise/index.markdown
+++ b/content/blog/2020-04-dplyr-1-0-0-colwise/index.markdown
@@ -49,7 +49,7 @@ df %>%
   summarise(a = mean(a), b = mean(b), c = mean(c), d = mean(c))
 ```
 
-You can now rewrite such code using `across()`, which lets you apply a transformation to multiple variables selected with the same syntax as [`select()` and `rename()`]( [tidy selection](https://www.tidyverse.org/blog/2020/03/dplyr-1-0-0-select-rename-relocate/#select-and-renaming)):
+You can now rewrite such code using `across()`, which lets you apply a transformation to multiple variables selected with the same syntax as [`select()` and `rename()`](https://www.tidyverse.org/blog/2020/03/dplyr-1-0-0-select-rename-relocate/#select-and-renaming):
 
 
 ```r


### PR DESCRIPTION
* Fix link to `select()` and `rename()` post in the `across()` post; now links to post directly—if the desired setup was to have tidy select linked to in parentheses, I can easily just remove the square braces around "`select()` and `rename()`" from the current version (see as-is below):
<img width="812" alt="image" src="https://user-images.githubusercontent.com/831732/79569811-96567980-8075-11ea-8c70-3098ace6d7f7.png">
