### PR TITLE
Conditional events sidebar

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -44,7 +44,6 @@
           {{ .TableOfContents }}
         </div>
         <div class="section">
-          <div class="sectionTitle">Upcoming events</div>
           {{ partial "events_sticky" . }}
         </div>
       </div>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -10,7 +10,6 @@
         </div>
 
         <div class="section">
-          <div class="sectionTitle">Upcoming events</div>
           {{ partial "events_sticky" . }}
         </div>
       </div>

--- a/themes/hugo-tourmaline/layouts/partials/events_sticky.html
+++ b/themes/hugo-tourmaline/layouts/partials/events_sticky.html
@@ -1,4 +1,9 @@
 {{ $pages := first 2 (where (where (where $.Site.RegularPages "Section" "events") "Type" "!=" "event-archive") "Date" "ge" now).ByDate }}
+
+{{ if gt (len $pages) 0 }}
+<div class="sectionTitle"><a href="{{ "/events/" | relURL }}">Upcoming events</a></div>
+{{ end }}
+
 {{ range $pages }}
 
 <div class="event">

--- a/themes/hugo-tourmaline/layouts/partials/head_includes.html
+++ b/themes/hugo-tourmaline/layouts/partials/head_includes.html
@@ -31,6 +31,10 @@
 {{- end }}
 {{- partial "head_highlightjs" . -}}
 
+{{ range .Site.Params.custom_js }}
+  <script type="text/javascript" src="{{ "/js/" | relURL }}{{ . }}"></script>
+{{ end }}
+
 <link rel="icon" href="{{ "images/favicon.ico" | relURL }}" />
 {{- if eq .Section "blog" -}}
 <link rel="alternate" type="application/atom+xml" title="Blog" href="/blog/index.xml" />

--- a/themes/hugo-tourmaline/layouts/partials/nav.html
+++ b/themes/hugo-tourmaline/layouts/partials/nav.html
@@ -3,7 +3,10 @@
   <div id="menuItems" class="">
     {{ $page := . }}
     {{ range .Site.Menus.main }}
-    <a class="menuItem {{ if eq $page.Section (trim .URL "/") }}current{{ end }}" href="{{ .URL }}">{{- .Pre -}}{{ .Name | safeHTML }}{{- .Post -}}</a>
+      {{ $active := or ($page.IsMenuCurrent "main" .) ($page.HasMenuCurrent "main" .) }}
+      {{ $active = or $active (eq $page.Section (trim .URL "/")) }}
+      {{ $active = or $active (eq $page.RelPermalink .URL ) }}
+    <a class="menuItem {{ if $active }}current{{ end }}" href="{{ .URL }}">{{- .Pre -}}{{ .Name | safeHTML }}{{- .Post -}}</a>
     {{ end }}
   </div>
 </div>

--- a/themes/hugo-tourmaline/layouts/partials/sidebar.html
+++ b/themes/hugo-tourmaline/layouts/partials/sidebar.html
@@ -10,7 +10,6 @@
         </div>
 
         <div class="section">
-          <div class="sectionTitle"><a href="{{ "/events/" | relURL }}">Upcoming events</a></div>
           {{ partial "events_sticky" . }}
         </div>
       </div>

--- a/themes/hugo-tourmaline/static/css/main-site.css
+++ b/themes/hugo-tourmaline/static/css/main-site.css
@@ -951,7 +951,7 @@ ol {
 
 pre, code {
   font-family: "Source Code Pro", monospace;
-  background-color: #f8f8f8;
+  background-color: #f8f8f8 !important;
   font-size: 14px; }
 
 pre {
@@ -1316,6 +1316,7 @@ table tbody tr td{
 
 table tbody tr td:last-child{
   padding: 15px 0;
+}
 
 table, tbody, tfoot, thead, tr, th, td {
   margin: 0;


### PR DESCRIPTION
Fixes issue #408 in the base Hugo theme

Also updates two custom site layouts to remove section titles, as section titles are now conditional in the partial layout.

Also includes minor update to nav partial that shows single pages (like packages/help/contribute) as active links, like blog.