### PR TITLE
Disable highlightjs

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -16,6 +16,7 @@ hex_base_url = ".tidyverse.org"
 mainSections = ["blog"]
 
 # options for highlight.js (version, additional languages, and theme)
+disable_highlightjs = "true"
 highlightjsVersion = "9.11.0"
 highlightjsCDN = "//cdn.bootcss.com"
 highlightjsLang = ["r", "markdown"]

--- a/themes/hugo-tourmaline/exampleSite/config.toml
+++ b/themes/hugo-tourmaline/exampleSite/config.toml
@@ -36,3 +36,10 @@ preserveTaxonomyNames = true
 	angledQuotes = false
 	latexDashes = true
   extensions = ["backslashLineBreak"]
+
+[markup]
+  defaultMarkdownHandler = "goldmark"
+  [markup.goldmark.renderer]
+    unsafe = true
+  [markup.highlight]
+    style = "pygments"

--- a/themes/hugo-tourmaline/exampleSite/config/_default/params.toml
+++ b/themes/hugo-tourmaline/exampleSite/config/_default/params.toml
@@ -16,6 +16,7 @@ hex_base_url = ".tidyverse.org"
 mainSections = ["articles", "events"]
 
 # options for highlight.js (version, additional languages, and theme)
+disable_highlightjs = "true"
 highlightjsVersion = "9.11.0"
 highlightjsCDN = "//cdn.bootcss.com"
 highlightjsLang = ["r", "yaml"]

--- a/themes/hugo-tourmaline/layouts/partials/footer_highlightjs.html
+++ b/themes/hugo-tourmaline/layouts/partials/footer_highlightjs.html
@@ -1,3 +1,4 @@
+{{ if or (not .Site.Params.disable_highlightjs) (ne .Site.Params.disable_highlightjs "true") }}
 {{ if and (not .Params.disable_highlight) (in (string .Content) "</pre>") }}
 {{ $highVer := .Site.Params.highlightjsVersion }}
 {{ $highCDN := (.Site.Params.highlightjsCDN | default "//cdn.bootcss.com") }}
@@ -8,5 +9,6 @@
 {{ range ($.Scratch.Get "highLangs") }}
 <script src="{{ $highCDN }}/highlight.js/{{ $highVer }}/languages/{{ . }}.min.js"></script>{{ end }}
 <script>hljs.configure({languages: []}); hljs.initHighlightingOnLoad();</script>
+{{ end }}
 {{ end }}
 {{ end }}

--- a/themes/hugo-tourmaline/layouts/partials/head_highlightjs.html
+++ b/themes/hugo-tourmaline/layouts/partials/head_highlightjs.html
@@ -1,6 +1,8 @@
+{{ if or (not .Site.Params.disable_highlightjs) (ne .Site.Params.disable_highlightjs "true") }}
 {{ if and (not .Params.disable_highlight) (in (string .Content) "</pre>") }}
 {{ $highTheme := .Site.Params.highlightjsTheme }}
 {{ with .Site.Params.highlightjsVersion }}
 <link href='{{ $.Site.Params.highlightjsCDN | default "//cdn.bootcss.com" }}/highlight.js/{{ . }}/styles/{{ $highTheme }}.min.css' rel='stylesheet' type='text/css' />
+{{ end }}
 {{ end }}
 {{ end }}


### PR DESCRIPTION
Now that pygments can be used in Hugo, I noticed that our previous highlightjs was causing a conflict and overwriting some of the highlight elements. It was also leading to what you see when you currently load a post with code in it- the pygments version flickers but then turns gray, because the highlightjs kicks in. The Hugo theme now has a site parameter to disable highlightjs sitewide.

Before: 
<img width="929" alt="Screen Shot 2020-04-17 at 8 07 33 PM" src="https://user-images.githubusercontent.com/12160301/79626778-85dee700-80e7-11ea-8bf9-31a23f699d6c.png">

After: 
<img width="929" alt="Screen Shot 2020-04-17 at 8 07 44 PM" src="https://user-images.githubusercontent.com/12160301/79626780-8bd4c800-80e7-11ea-9f5f-3bbaad336e4f.png">

