### PR TITLE
Simplify netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,20 +1,6 @@
 [build]
   publish = "public"
-  command = "hugo"
-
-[context.production.environment]
-  HUGO_VERSION = "0.68.3"
-  HUGO_ENV = "production"
-  HUGO_ENABLEGITINFO = "true"
-
-[context.branch-deploy.environment]
-  HUGO_VERSION = "0.68.3"
-
-[context.deploy-preview.environment]
-  HUGO_VERSION = "0.68.3"
-
-[context.deploy-preview]
   command = "hugo -b $DEPLOY_PRIME_URL --buildFuture"
 
-[context.branch-deploy]
-  command = "hugo -b $DEPLOY_PRIME_URL --buildFuture"
+[build.environment]
+  HUGO_VERSION = "0.68.3"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   publish = "public"
-  command = "hugo -b $DEPLOY_PRIME_URL --buildFuture"
+  command = "hugo --baseURL $DEPLOY_PRIME_URL --buildFuture"
 
 [build.environment]
   HUGO_VERSION = "0.68.3"


### PR DESCRIPTION
* Set HUGO_VERSION for all builds

* Set command for all builds

* Rely on `hugo` defaulting to production environment, as [documented](https://gohugo.io/getting-started/configuration/#configuration-directory)

* Removed `HUGO_ENABLEGITINFO` since, as far as I can tell, it's not documented anywhere, and comes only from people copy and pasting from <https://gohugo.io/hosting-and-deployment/hosting-on-netlify/>