### PR TITLE
Fix code font sizing in headers + TOC

### DIFF
--- a/themes/hugo-graphite/static/css/main-site.css
+++ b/themes/hugo-graphite/static/css/main-site.css
@@ -1069,7 +1069,7 @@ pre code {
 
 /* this styles the inline code */
 code {
-  font-size: 1rem;
+  font-size: 1em;
   color: #606060;
   display: inline-block;
   margin: 1px 5px;
@@ -2139,3 +2139,5 @@ a > svg.anchor-symbol:hover {
 .listItem .itemImage {
     overflow: hidden;
  }
+ 
+


### PR DESCRIPTION
This fix makes code font size for inline code relative to direct or nearest parent (`em`), not root font size (`rem`). Pulls from upstream fix in Hugo Graphite theme.

Before:
https://www.tidyverse.org/blog/2020/07/tune-0-1-1/#better-autoplot

After:
https://deploy-preview-459--tidyverse-org.netlify.app/blog/2020/07/tune-0-1-1/#better-autoplot