### PR TITLE
Point out that usethis can take a ref; update your YAML, folks

### DIFF
--- a/content/blog/actions-2-0-0/index.Rmd
+++ b/content/blog/actions-2-0-0/index.Rmd
@@ -83,6 +83,9 @@ The `v2` tag is a *sliding* tag.
 It is not fixed to a certain version, but we regularly update it with (non-breaking) improvements and fixes.
 If it is absolutely crucial that your workflow runs the same way, use one of the fixed tags, e.g. `v2.2.2` is the most recent one.
 
+As of today, usethis v2.1.6 defaults to configuring workflows from the `v2` tag.
+But `use_github_action()` accepts a `ref` argument, which allows you specify a different tag (such as `v2.2.2`) or even a branch name or specific SHA.
+
 ## What is new?
 
 ### Make a plan and stick to it
@@ -106,6 +109,9 @@ If you update your existing workflows to use the `v2` actions, also take a look 
 These are typically much simpler than the previously suggested workflows, because we moved some workflow steps into the new actions.
 E.g. `check-r-package` always prints testthat output and it uploads the check directory as an artifact on failure, you don't need to do these explicitly in the workflow.
 `setup-r-dependencies` now prints the session info with all installed packages, no need to do this explicitly.
+
+To be clear, "updating your GHA workflows to `v2`" generally goes beyond just changing every instance of `v1` to `v2`.
+The example workflows have also evolved, i.e. you really need to update entire YAML workflow file.
 
 ### Snapshots as artifacts
 

--- a/content/blog/actions-2-0-0/index.md
+++ b/content/blog/actions-2-0-0/index.md
@@ -19,7 +19,7 @@ tags: ["GitHub Actions"]
 editor_options:
   markdown:
     wrap: sentence
-rmd_hash: 5f21cb438f0fec8c
+rmd_hash: 1858a1e17bf4e92c
 
 ---
 
@@ -78,6 +78,8 @@ In short, use the `v2` tag.
 
 The `v2` tag is a *sliding* tag. It is not fixed to a certain version, but we regularly update it with (non-breaking) improvements and fixes. If it is absolutely crucial that your workflow runs the same way, use one of the fixed tags, e.g. `v2.2.2` is the most recent one.
 
+As of today, usethis v2.1.6 defaults to configuring workflows from the `v2` tag. But `use_github_action()` accepts a `ref` argument, which allows you specify a different tag (such as `v2.2.2`) or even a branch name or specific SHA.
+
 ## What is new?
 
 ### Make a plan and stick to it
@@ -98,6 +100,8 @@ See the `setup-r-dependencies` [README](https://github.com/r-lib/actions/tree/v2
 ### Simpler workflow files
 
 If you update your existing workflows to use the `v2` actions, also take a look at the new [example workflows](https://github.com/r-lib/actions/tree/v2/examples). These are typically much simpler than the previously suggested workflows, because we moved some workflow steps into the new actions. E.g. `check-r-package` always prints testthat output and it uploads the check directory as an artifact on failure, you don't need to do these explicitly in the workflow. `setup-r-dependencies` now prints the session info with all installed packages, no need to do this explicitly.
+
+To be clear, "updating your GHA workflows to `v2`" generally goes beyond just changing every instance of `v1` to `v2`. The example workflows have also evolved, i.e. you really need to update entire YAML workflow file.
 
 ### Snapshots as artifacts
 


### PR DESCRIPTION
It seems worth pointing out that usethis will grab `v2` today, but that it can also be directed to any `ref`.

Also, I've definitely encountered the notion that updating to `v2` can be accomplished by doing find-and-replace `v1` --> `v2`, so I think we should be super clear that it goes beyond that.