### PR TITLE
Add a quick nod to data.table's behind-the-scenes role in sort speed

### DIFF
--- a/content/blog/dplyr-1-1-0-is-coming-soon/index.Rmd
+++ b/content/blog/dplyr-1-1-0-is-coming-soon/index.Rmd
@@ -295,7 +295,7 @@ Now, I'll be honest, I'm being a bit tricky here.
 The new backend for `arrange()` comes with a meaningful change in behavior - it now sorts character strings in the C locale by default, rather than in the much slower system locale (American English, for me).
 We made this change for two main reasons:
 
--   Much faster performance by default
+-   Much faster performance by default, because it can re-use data.table's radix sort algorithm
 
 -   Improved reproducibility across R sessions, where different computers might use different system locales
 

--- a/content/blog/dplyr-1-1-0-is-coming-soon/index.Rmd
+++ b/content/blog/dplyr-1-1-0-is-coming-soon/index.Rmd
@@ -295,7 +295,7 @@ Now, I'll be honest, I'm being a bit tricky here.
 The new backend for `arrange()` comes with a meaningful change in behavior - it now sorts character strings in the C locale by default, rather than in the much slower system locale (American English, for me).
 We made this change for two main reasons:
 
--   Much faster performance by default, because it can re-use data.table's radix sort algorithm
+-   Much faster performance by default, because it can use {vctrs} radix sort (inspired by data.table)
 
 -   Improved reproducibility across R sessions, where different computers might use different system locales
 


### PR DESCRIPTION
Exciting stuff coming up in the new version!

Proposing a quick h/t to data.table for the radix sort code (unless I'm perhaps mistaken?).

data.table is already cited as inspiration in two other places in the post (thanks for that, and great to hear!), hope you agree it makes sense to do so here as well.

Open to ideas for how else to word it.