### PR TITLE
Update r4ds url

### DIFF
--- a/content/home/band_two.md
+++ b/content/home/band_two.md
@@ -5,6 +5,6 @@ alt_text: "R for Data Science book cover"
 url_image: http://amzn.to/2aHLAQ1
 ---
 
-See how the tidyverse makes data science faster, easier and more fun with "R for Data Science". Read it [online](http://r4ds.had.co.nz/), buy [the book](http://amzn.to/2aHLAQ1) or try another [resource](/learn/) from the community.
+See how the tidyverse makes data science faster, easier and more fun with "R for Data Science (2e)". Read it [online](https://r4ds.hadley.nz/), buy [the book](http://amzn.to/2aHLAQ1) or try another [resource](/learn/) from the community.
    
    


### PR DESCRIPTION
- This pull request updates r4ds(<https://r4ds.had.co.nz/>) to r4ds 2e (https://r4ds.hadley.nz/) on the homepage.
- The current amazon link in **:scroll: content\home\band_two.md** also points to the 1st edition (http://amzn.to/2aHLAQ1) but I did not edited that part to not create an accidental referenced link etc.