### PR TITLE
Fix broken link in blog post by using absolute URL

### DIFF
--- a/content/blog/2023/tidymodels-errors-q4/index.Rmd
+++ b/content/blog/2023/tidymodels-errors-q4/index.Rmd
@@ -42,7 +42,7 @@ pak::pak(paste0("tidymodels/", c("tune", "parsnip", "recipes")))
 
 ## The outcome went missing `r emo::ji("ghost")` {#outcome}
 
-The tidymodels packages focus on _supervised_ machine learning problems, predicting the value of an outcome using predictors.^[See the [tidyclust](tidyclust.tidymodels.org) package for unsupervised learning with tidymodels!] For example, in the code:
+The tidymodels packages focus on _supervised_ machine learning problems, predicting the value of an outcome using predictors.^[See the [tidyclust](https://tidyclust.tidymodels.org) package for unsupervised learning with tidymodels!] For example, in the code:
 
 ```{r}
 linear_spec <- linear_reg()

--- a/content/blog/2023/tidymodels-errors-q4/index.md
+++ b/content/blog/2023/tidymodels-errors-q4/index.md
@@ -15,7 +15,7 @@ photo:
 
 categories: [programming] 
 tags: [tidymodels, package maintenance, tune, parsnip]
-rmd_hash: bd6d689cf1e0592d
+rmd_hash: ba5e0be9e276feef
 
 ---
 
@@ -333,5 +333,5 @@ While I've only outlined three, there are all sorts of improvements to error mes
 
 [^1]: Issue triage consists of categorizing, prioritizing, and consolidating issues in a repository's issue tracker.
 
-[^2]: See the [tidyclust](tidyclust.tidymodels.org) package for unsupervised learning with tidymodels!
+[^2]: See the [tidyclust](https://tidyclust.tidymodels.org) package for unsupervised learning with tidymodels!
 


### PR DESCRIPTION
Hi, all! This is just a tiny link fix. I was appreciating a fab recent blog when I got a 404. Clicking on a {tidyclust} link sent me to https://www.tidyverse.org/blog/2023/11/tidymodels-errors-q4/tidyclust.tidymodels.org

I think (🤞) adding https:// fixes that