### PR TITLE
fix: Avoid putting `<body>` inside `<head>`

### DIFF
--- a/themes/hugo-graphite/layouts/_default/baseof.html
+++ b/themes/hugo-graphite/layouts/_default/baseof.html
@@ -1,14 +1,39 @@
 <!DOCTYPE html>
 <html>
+
 <head>
 {{ partial "header.html" . }}
 </head>
+
 <body>
-
-
- {{ block "main" . }}
+  <div id="appTidyverseSite" {{ if not .IsHome }}class="shrinkHeader alwaysShrinkHeader" {{ end }}>
+    <div id="main">
+      <!-- rstudio header -->
+      <div id="rStudioHeader">
+        <nav class="band">
+          <div class="innards bandContent">
+            <div>
+              {{ if .Site.Params.logo.image }}
+              <a href="{{ " /" | relURL }}" class="nav-logo">
+                <img src="{{ print " images/" .Site.Params.logo.image | relURL }}" width="{{ .Site.Params.logo.width }}"
+                  height="{{ .Site.Params.logo.height }}" alt="{{ .Site.Params.logo.alt }}">
+              </a>
+              {{- else -}}
+              <a class="productName" href="{{ " /" | relLangURL }}">{{- .Site.Title -}}</a>
+              {{ end }}
+            </div>
+            {{ partial "nav.html" . }}
+          </div>
+        </nav>
+      </div>
+      <main>
+        {{ block "main" . }}
+      </main>
       <!-- The part of the page that begins to differ between templates -->
- {{ end }}
-{{ partial "footer.html" . }}
+      {{ end }}
+      {{ partial "footer.html" . }}
+    </div>
+  </div>
 </body>
+
 </html>

--- a/themes/hugo-graphite/layouts/partials/header.html
+++ b/themes/hugo-graphite/layouts/partials/header.html
@@ -3,24 +3,3 @@
 
 <!--this loads all stylesheets, metadata tags, favicons, and jquery -->
 {{ partial "head_includes.html" . }}
-
-  <body>
-    <div id="appTidyverseSite" {{ if not .IsHome }}class="shrinkHeader alwaysShrinkHeader"{{ end }}>
-      <div id="main">
-        <!-- rstudio header -->
-        <div id="rStudioHeader">
-          <div class="band">
-            <div class="innards bandContent">
-              <div>
-                {{ if .Site.Params.logo.image }}
-                    <a href="{{ "/" | relURL }}" class="nav-logo">
-                      <img src="{{ print "images/" .Site.Params.logo.image | relURL }}" width="{{ .Site.Params.logo.width }}" height="{{ .Site.Params.logo.height }}" alt="{{ .Site.Params.logo.alt }}">
-                    </a>
-                {{- else -}}
-                <a class="productName" href="{{ "/" | relLangURL }}">{{- .Site.Title -}}</a>
-                {{ end }}
-              </div>
-              {{ partial "nav.html" . }}
-            </div>
-          </div>
-        </div>

--- a/themes/hugo-graphite/static/css/main-site.css
+++ b/themes/hugo-graphite/static/css/main-site.css
@@ -95,7 +95,7 @@ html, body {
   /* to help push the footer down */
   height: 100%; }
 
-#root, #appShinySite, #main {
+#root, #appTidyverseSite, #main {
   position: absolute;
   top: 0px;
   left: 0px;


### PR DESCRIPTION
Currently, the tidyverse site has some content that _should be_ in the body of the page that's instead being placed in the `<head>` element via the `header.html` partial.

This causes some wonky HTML that's generally resolved by web browsers but introduces semantic errors that make it hard to use tools like `markitdown` to read the contents of the tidyverse blog.

This PR resolves those issues by moving the content from the `header.html` partial to the `baseof.html` partial.

While here, I also wrapped the main content in a `<main>` tag and replaced `div.band` with `nav.band` so that the header links are placed in an appropriate landmark area.

cc @t-kalinowski 